### PR TITLE
Change template.mf so that the Bundlor MANIFEST will import

### DIFF
--- a/org.eclipse.virgo.bundlor/template.mf
+++ b/org.eclipse.virgo.bundlor/template.mf
@@ -6,7 +6,7 @@ Bundle-SymbolicName: ${bundleName}
 Bundle-Version: ${version}
 Import-Template: 
  javax.xml.*;version="0",
- org.objectweb.asm.*;version="${objectwebAsmVersion:[=.=.=, +1.0.0)}",
+ org.objectweb.asm.*;version="0",
  org.osgi.framework;version="0",
  org.w3c.dom.*;version="0",
  org.xml.*;version="0",


### PR DESCRIPTION
org.objectweb.asm without requiring a specific version (actually, using the wildcard version="0")

Fixes #4